### PR TITLE
Fixed building with newest rust version

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -34,7 +34,7 @@ pub trait SharedVertex<V> {
     }
 }
 
-pub struct ShareVertexIterator<'a, T, V> {
+pub struct ShareVertexIterator<'a, T:'a, V> {
     base: &'a T,
     idx: Range<uint>
 }
@@ -65,7 +65,7 @@ pub trait IndexedPolygon<V> {
     }
 }
 
-pub struct IndexedPolygonIterator<'a, T, V> {
+pub struct IndexedPolygonIterator<'a, T:'a, V> {
     base: &'a T,
     idx: Range<uint>
 }


### PR DESCRIPTION
After rust update genmesh didn't compile

```
src/generator.rs:37:1: 40:2 error: the parameter type `T` may not live long enough; consider adding an explicit lifetime bound `T:'a`...
src/generator.rs:37 pub struct ShareVertexIterator<'a, T, V> {
src/generator.rs:38     base: &'a T,
src/generator.rs:39     idx: Range<uint>
src/generator.rs:40 }
src/generator.rs:37:1: 40:2 note: ...so that the reference type `&'a T` does not outlive the data it points at
src/generator.rs:37 pub struct ShareVertexIterator<'a, T, V> {
src/generator.rs:38     base: &'a T,
src/generator.rs:39     idx: Range<uint>
src/generator.rs:40 }
src/generator.rs:68:1: 71:2 error: the parameter type `T` may not live long enough; consider adding an explicit lifetime bound `T:'a`...
src/generator.rs:68 pub struct IndexedPolygonIterator<'a, T, V> {
src/generator.rs:69     base: &'a T,
src/generator.rs:70     idx: Range<uint>
src/generator.rs:71 }
src/generator.rs:68:1: 71:2 note: ...so that the reference type `&'a T` does not outlive the data it points at
src/generator.rs:68 pub struct IndexedPolygonIterator<'a, T, V> {
src/generator.rs:69     base: &'a T,
src/generator.rs:70     idx: Range<uint>
src/generator.rs:71 }
error: aborting due to 2 previous errors
Could not compile `genmesh`.
```
