### PR TITLE
Removed debug crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@
 
 
 extern crate core;
-extern crate debug;
 
 pub use poly::{
     Quad,


### PR DESCRIPTION
The debug crate doesn't exist anymore, and genmesh wasn't using it anyway, so this Pull Request makes it build under the latest Rust.
