### PR TITLE
fix rfc 1214 fallout

### DIFF
--- a/src/poly.rs
+++ b/src/poly.rs
@@ -226,7 +226,7 @@ impl<T: Clone, U> MapVertex<T, U> for Polygon<T> {
 /// and modify the vertices in a polygon. This is useful if you need to scale
 /// the mesh using a matrix multiply, or just for modifying the type of each
 /// vertex.
-pub trait MapToVertices<T, U> {
+pub trait MapToVertices<T, U>: Sized {
     /// `Output` should be a a container of the same shape of the type
     /// It's internal values should reflect any transformation the map did.
     type Output;
@@ -344,7 +344,7 @@ impl<T: Clone> EmitLines for Polygon<T> {
 }
 
 /// Creates an LinesIterator from another Iterator
-pub trait Lines {
+pub trait Lines: Sized {
     /// The type of each point in the lines
     type Vertex;
 


### PR DESCRIPTION
[RFC 1214](https://github.com/rust-lang/rfcs/blob/master/text/1214-projections-lifetimes-and-wf.md) fixed some bugs / incorrect behaviour in `rustc` which requires additional bounds in some places.

The errors were:
```plain
rc/poly.rs:236:5: 237:32 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/poly.rs:236     fn vertex<F>(self, map: F) -> MapToVerticesIter<Self, T, U, F>
src/poly.rs:237         where F: FnMut(T) -> U;
src/poly.rs:236:5: 237:32 help: run `rustc --explain E0277` to see a detailed explanation
src/poly.rs:236:5: 237:32 note: `Self` does not have a constant size known at compile-time
src/poly.rs:236     fn vertex<F>(self, map: F) -> MapToVerticesIter<Self, T, U, F>
src/poly.rs:237         where F: FnMut(T) -> U;
src/poly.rs:236:5: 237:32 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/poly.rs:236     fn vertex<F>(self, map: F) -> MapToVerticesIter<Self, T, U, F>
src/poly.rs:237         where F: FnMut(T) -> U;
src/poly.rs:236:5: 237:32 note: required by `poly::MapToVerticesIter`
src/poly.rs:236     fn vertex<F>(self, map: F) -> MapToVerticesIter<Self, T, U, F>
src/poly.rs:237         where F: FnMut(T) -> U;

src/poly.rs:352:5: 352:57 warning: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
src/poly.rs:352     fn lines(self) -> LinesIterator<Self, Self::Vertex>;
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/poly.rs:352:5: 352:57 help: run `rustc --explain E0277` to see a detailed explanation
src/poly.rs:352:5: 352:57 note: `Self` does not have a constant size known at compile-time
src/poly.rs:352     fn lines(self) -> LinesIterator<Self, Self::Vertex>;
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/poly.rs:352:5: 352:57 note: this warning results from recent bug fixes and clarifications; it will become a HARD ERROR in the next release. See RFC 1214 for details.
src/poly.rs:352     fn lines(self) -> LinesIterator<Self, Self::Vertex>;
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/poly.rs:352:5: 352:57 note: required by `poly::LinesIterator`
src/poly.rs:352     fn lines(self) -> LinesIterator<Self, Self::Vertex>;
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```