### PR TITLE
Bullet-proof generators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genmesh"
-version = "0.4.2"
+version = "0.4.3"
 authors = [
     "Colin Sherratt <colin.sherratt@gmail.com>",
     "Dzmitry Malyshau <kvarkus@gmail.com",

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -37,8 +37,8 @@ impl Plane {
 
     /// create a subdivided plane. This can be used to build
     /// a grid of points.
-    /// x is the number of subdivisions in the x axis
-    /// y is the number of subdivisions in the y axis
+    /// `x` is the number of subdivisions in the x axis
+    /// `y` is the number of subdivisions in the y axis
     pub fn subdivide(x: usize, y: usize) -> Plane {
         assert!(x > 0 && y > 0);
         Plane {
@@ -62,17 +62,18 @@ impl Iterator for Plane {
     type Item = Quad<(f32, f32)>;
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let n = (self.subdivide_y - self.y) * self.subdivide_x + (self.subdivide_x - self.x);
+        let n = (self.subdivide_y - self.y) * self.subdivide_x +
+                (self.subdivide_x - self.x);
         (n, Some(n))
     }
 
     fn next(&mut self) -> Option<Quad<(f32, f32)>> {
         if self.x == self.subdivide_x {
-            self.x = 0;
             self.y += 1;
-            if self.y == self.subdivide_y {
+            if self.y >= self.subdivide_y {
                 return None;
             }
+            self.x = 0;
         }
 
         let x = self.vert(self.x,   self.y);
@@ -100,14 +101,14 @@ impl SharedVertex<(f32, f32)> for Plane {
 
 impl IndexedPolygon<Quad<usize>> for Plane {
     fn indexed_polygon(&self, idx: usize) -> Quad<usize> {
-        let y = idx / (self.subdivide_x);
-        let y = y * (self.subdivide_x+1);
+        let y = idx / self.subdivide_x;
         let x = idx % self.subdivide_x;
+        let base = y * (self.subdivide_x + 1) + x;
 
-        Quad::new((x+y) + self.subdivide_x + 1,
-                  (x+y),
-                  (x+y) + 1,
-                  (x+y) + self.subdivide_x + 2)
+        Quad::new(base,
+                  base + 1,
+                  base + self.subdivide_x + 2,
+                  base + self.subdivide_x + 1)
     }
 
     fn indexed_polygon_count(&self) -> usize {

--- a/tests/generate.rs
+++ b/tests/generate.rs
@@ -18,11 +18,15 @@ extern crate genmesh;
 use std::fmt::Debug;
 use genmesh::{
     generators,
-    Triangle,
     EmitTriangles,
+    MapVertex,
     Triangulate,
 };
 
+/// Test a generator by comparing two triangular meshes:
+/// 1) by using the `Iterator` implementation of the given generator
+/// 2) by producing shared vertices and sampling them with the
+///    produced indexed polygons.
 fn test<F, P, G>(generator: G) where
     F: EmitTriangles,
     F::Vertex: Clone + Copy + Debug + PartialEq,
@@ -33,14 +37,10 @@ fn test<F, P, G>(generator: G) where
 {
     let vertices: Vec<_> = generator.shared_vertex_iter()
                                     .collect();
-    let fun = |f: Triangle<usize>| {
-        Triangle::new(vertices[f.x],
-                      vertices[f.y],
-                      vertices[f.z])
-    };
+
     let f1: Vec<_> = generator.indexed_polygon_iter()
                               .triangulate()
-                              .map(fun)
+                              .map(|f| f.map_vertex(|u| vertices[u]))
                               .collect();
     let f0: Vec<_> = generator.triangulate()
                               .collect();
@@ -52,22 +52,22 @@ fn test<F, P, G>(generator: G) where
 }
 
 #[test]
-fn plane() {
+fn gen_plane() {
     test(generators::Plane::new());
     test(generators::Plane::subdivide(3, 4));
 }
 
 #[test]
-fn cube() {
+fn gen_cube() {
     test(generators::Cube::new());
 }
 
 #[test]
-fn cylinder() {
+fn gen_cylinder() {
     test(generators::Cylinder::new(5));
 }
 
 #[test]
-fn sphere_uv() {
+fn gen_sphere_uv() {
     test(generators::SphereUV::new(4, 3));
 }

--- a/tests/generate.rs
+++ b/tests/generate.rs
@@ -1,0 +1,73 @@
+//   Copyright Dzmitry Malyshau 2017
+//   
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//   
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+extern crate cgmath;
+extern crate genmesh;
+
+use std::fmt::Debug;
+use genmesh::{
+    generators,
+    Triangle,
+    EmitTriangles,
+    Triangulate,
+};
+
+fn test<F, P, G>(generator: G) where
+    F: EmitTriangles,
+    F::Vertex: Clone + Copy + Debug + PartialEq,
+    P: EmitTriangles<Vertex = usize>,
+    G: generators::SharedVertex<F::Vertex> +
+       generators::IndexedPolygon<P> +
+       Iterator<Item = F>,
+{
+    let vertices: Vec<_> = generator.shared_vertex_iter()
+                                    .collect();
+    let fun = |f: Triangle<usize>| {
+        Triangle::new(vertices[f.x],
+                      vertices[f.y],
+                      vertices[f.z])
+    };
+    let f1: Vec<_> = generator.indexed_polygon_iter()
+                              .triangulate()
+                              .map(fun)
+                              .collect();
+    let f0: Vec<_> = generator.triangulate()
+                              .collect();
+
+    assert_eq!(f0.len(), f1.len());
+    for (i, (p0, p1)) in f0.iter().zip(f1.iter()).enumerate() {
+        assert_eq!(p0, p1, "Mismatched polygon[{}]", i);
+    }
+}
+
+#[test]
+fn plane() {
+    test(generators::Plane::new());
+    test(generators::Plane::subdivide(3, 4));
+}
+
+#[test]
+fn cube() {
+    test(generators::Cube::new());
+}
+
+#[test]
+fn cylinder() {
+    test(generators::Cylinder::new(5));
+}
+
+#[test]
+fn sphere_uv() {
+    test(generators::SphereUV::new(4, 3));
+}

--- a/tests/winding.rs
+++ b/tests/winding.rs
@@ -1,0 +1,94 @@
+//   Copyright Dzmitry Malyshau 2017
+//   
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//   
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+extern crate cgmath;
+extern crate genmesh;
+
+use cgmath::{
+    InnerSpace,
+};
+use genmesh::{
+    generators,
+    Line,
+    EmitLines,
+    MapVertex,
+};
+
+type Vertex = (f32, f32, f32);
+
+struct Edge {
+    dir: cgmath::Vector3<f32>,
+    mid: cgmath::Vector3<f32>,
+}
+
+impl Edge {
+    fn new(Line{ x, y }: Line<Vertex>) -> Self {
+        Edge {
+            dir: cgmath::vec3(y.0 - x.0, y.1 - x.1, y.2 - x.2),
+            mid: cgmath::vec3(y.0 + x.0, y.1 + x.1, y.2 + x.2) * 0.5,
+        }
+    }
+
+    /// Check that the corner `(self, e)` has outward winding order
+    /// (thus, it's normal is in the same hemisphere as it's offset).
+    fn check_to(&self, e: &Edge) {
+        let normal = self.dir.cross(e.dir);
+        let mid = (self.mid + e.mid) * 0.5;
+        assert!(normal.dot(mid) > 0.0);
+    }
+}
+
+/// Make sure that all the polygons in the `poly_iter` have the outward
+/// winding order relative to the origin of the coordinate system.
+/// This is a simplified (and incomplete) convex shape test.
+fn test<P, I>(poly_iter: I) where
+    P: EmitLines<Vertex=Vertex>,
+    I: Iterator<Item=P>,
+{
+    let mut edges = Vec::new();
+    for poly in poly_iter {
+        edges.clear();
+        poly.emit_lines(|l| edges.push(Edge::new(l)));
+        // check last-first corner first, since it wraps
+        edges.last().unwrap().check_to(&edges[0]);
+        // check all the non-wrapping corners
+        for (a, b) in edges.iter().zip(edges[1..].iter()) {
+            a.check_to(b);
+        }
+    }
+}
+
+
+#[test]
+fn wind_plane() {
+    test(generators::Plane::new()
+        .map(|p| p.map_vertex(|(x, y)| (x, y, 1f32))));
+    test(generators::Plane::subdivide(3, 4)
+        .map(|p| p.map_vertex(|(x, y)| (x, y, 1f32))));
+}
+
+#[test]
+fn gen_cube() {
+    test(generators::Cube::new());
+}
+
+#[test]
+fn gen_cylinder() {
+    test(generators::Cylinder::new(5));
+}
+
+#[test]
+fn gen_sphere_uv() {
+    test(generators::SphereUV::new(4, 3));
+}


### PR DESCRIPTION
Fixes #39

Adds 2 new test groups:
  - `generate` checks that non-shared mesh matches exactly the shared+indexed one. This doesn't quite enforce the generated stuff to be correct, but at least it's more difficult to write the same wrong thing in two different ways :)
  - `winding` checks for the winding order of the polygons to be consistent and pointing outwards of the center. This will be more difficult for torus (#23), but we are not there yet.

Of course, I had to make fixes for the tests to actually pass. For example, when wrapping around a circle and taking `sin/cos` of `2*Pi`, we were getting rounding errors, which would eventually propagate into the mesh cracks. Now we catch those, and our meshes are seamless.

r? @csherratt