### PR TITLE
Fix the normals for the cylinder's bottom edge loop.

### DIFF
--- a/src/cylinder.rs
+++ b/src/cylinder.rs
@@ -152,6 +152,9 @@ impl IndexedPolygon<Polygon<usize>> for Cylinder {
             let start = 0;
             Polygon::PolyTri(Triangle::new(base + u, start, base + u1))
         } else if h == self.sub_h {
+            // We need to to select the next vertex loop over, which
+            // has the correct normals.
+            let base = base + self.sub_u;
             let end = self.shared_vertex_count() - 1;
             Polygon::PolyTri(Triangle::new(base + u, base + u1, end))
         } else {


### PR DESCRIPTION
We were selecting the wrong set of vertices for the bottom plane, and while
they had the correct positions, they contained the incorrect normal.

Before: 
![before](https://cloud.githubusercontent.com/assets/26073376/26566276/e749c3d2-44bf-11e7-83d0-5dedfa07b637.png)

After:
![after](https://cloud.githubusercontent.com/assets/26073376/26566280/ee00a920-44bf-11e7-969c-f4da433e48ac.png)

