### PR TITLE
SphereUV -> SphereUv

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub mod generators {
     pub use cube::Cube;
     pub use cylinder::Cylinder;
     pub use plane::Plane;
-    pub use sphere::SphereUV;
+    pub use sphere::SphereUv;
     pub use torus::Torus;
 }
 

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -20,20 +20,20 @@ use super::generators::{SharedVertex, IndexedPolygon};
 
 /// Represents a sphere with radius of 1, centered at (0, 0, 0)
 #[derive(Clone, Copy)]
-pub struct SphereUV {
+pub struct SphereUv {
     u: usize,
     v: usize,
     sub_u: usize,
     sub_v: usize,
 }
 
-impl SphereUV {
+impl SphereUv {
     /// Create a new sphere.
     /// `u` is the number of points across the equator of the sphere.
     /// `v` is the number of points from pole to pole.
     pub fn new(u: usize, v: usize) -> Self {
         assert!(u > 1 && v > 1);
-        SphereUV {
+        SphereUv {
             u: 0,
             v: 0,
             sub_u: u,
@@ -50,7 +50,7 @@ impl SphereUV {
     }
 }
 
-impl Iterator for SphereUV {
+impl Iterator for SphereUv {
     type Item = Polygon<Vertex>;
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -90,7 +90,7 @@ impl Iterator for SphereUV {
     }
 }
 
-impl SharedVertex<Vertex> for SphereUV {
+impl SharedVertex<Vertex> for SphereUv {
     fn shared_vertex(&self, idx: usize) -> Vertex {
         if idx == 0 {
             self.vert(0, 0)
@@ -111,7 +111,7 @@ impl SharedVertex<Vertex> for SphereUV {
     }
 }
 
-impl IndexedPolygon<Polygon<usize>> for SphereUV {
+impl IndexedPolygon<Polygon<usize>> for SphereUv {
     fn indexed_polygon(&self, idx: usize) -> Polygon<usize> {
         let f = |u: usize, v: usize| if v == 0 {
             0

--- a/tests/generate.rs
+++ b/tests/generate.rs
@@ -64,7 +64,7 @@ fn gen_cylinder() {
 
 #[test]
 fn gen_sphere_uv() {
-    test(generators::SphereUV::new(4, 3));
+    test(generators::SphereUv::new(4, 3));
 }
 
 #[test]

--- a/tests/winding.rs
+++ b/tests/winding.rs
@@ -144,8 +144,8 @@ fn gen_cylinder() {
 
 #[test]
 fn gen_sphere_uv() {
-    test_outward(generators::SphereUV::new(4, 3));
-    test_closed(generators::SphereUV::new(4, 3));
+    test_outward(generators::SphereUv::new(4, 3));
+    test_closed(generators::SphereUv::new(4, 3));
 }
 
 #[test]


### PR DESCRIPTION
This PR renames `SphereUV` as `SphereUv` in order to adhere the Rust naming conventions.