### PR TITLE
Fixed author list in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "genmesh"
 version = "0.5.0"
 authors = [
     "Coraline Sherratt <cora.sherratt@gmail.com>",
-    "Dzmitry Malyshau <kvarkus@gmail.com",
+    "Dzmitry Malyshau <kvarkus@gmail.com>",
 ]
 
 license = "Apache-2.0"


### PR DESCRIPTION
There was a missing `>` in one of the author's email address. This causes it to display incorrectly on crates.io.