### PR TITLE
fix: All normals for a circle should point straight up

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "genmesh"
-version = "0.6.1"
+version = "0.6.2"
 authors = [
     "Coraline Sherratt <cora.sherratt@gmail.com>",
     "Dzmitry Malyshau <kvarkus@gmail.com>",

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -31,7 +31,7 @@ impl Circle {
             let p = [u.cos(), u.sin(), 0.];
             Vertex {
                 pos: p.into(),
-                normal: p.into(),
+                normal: [0., 0., 1.].into(),
             }
         }
     }
@@ -106,7 +106,7 @@ mod tests {
         assert_eq!(
             Some(&Vertex {
                 pos: [0.707107, -0.70710653, 0.0].into(),
-                normal: [0.707107, -0.70710653, 0.0].into()
+                normal: [0., 0., 1.].into()
             }),
             circle.shared_vertex_iter().collect::<Vec<_>>().last()
         );


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gfx-rs/genmesh/62)
<!-- Reviewable:end -->
