### PR TITLE
Add ExactSizeIterator for most iterators

### DIFF
--- a/src/circle.rs
+++ b/src/circle.rs
@@ -41,7 +41,7 @@ impl Iterator for Circle {
     type Item = Polygon<Vertex>;
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.sub_u, Some(self.sub_u))
+        (self.len(), Some(self.len()))
     }
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -62,6 +62,12 @@ impl Iterator for Circle {
                 self.vert(self.u),
             )))
         }
+    }
+}
+
+impl ExactSizeIterator for Circle {
+    fn len(&self) -> usize {
+        self.sub_u - self.u + 1
     }
 }
 

--- a/src/cone.rs
+++ b/src/cone.rs
@@ -121,7 +121,7 @@ impl Iterator for Cone {
 
 impl ExactSizeIterator for Cone {
     fn len(&self) -> usize {
-        self.sub_u * 2
+        self.sub_u * 2 - self.u
     }
 }
 
@@ -168,15 +168,11 @@ impl IndexedPolygon<Triangle<usize>> for Cone {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_cone() {
-        let cone = Cone::new(8);
-        assert_eq!((16, Some(16)), cone.size_hint());
-        assert_eq!(25, cone.shared_vertex_count());
-        assert_eq!(16, cone.indexed_polygon_count());
-    }
+#[test]
+fn test_cone_len() {
+    let mut cone = Cone::new(5);
+    assert_eq!(10, cone.len());
+    cone.next();
+    assert_eq!(9, cone.len());
+    assert_eq!(9, cone.count());
 }

--- a/src/cone.rs
+++ b/src/cone.rs
@@ -46,7 +46,8 @@ impl Cone {
                         pos.cos() * FRAC_1_SQRT_2,
                         pos.sin() * FRAC_1_SQRT_2,
                         -FRAC_1_SQRT_2,
-                    ].into(),
+                    ]
+                    .into(),
                 }
             }
             VertexSection::TopRadius(i) => {
@@ -57,7 +58,8 @@ impl Cone {
                         pos.cos() * FRAC_1_SQRT_2,
                         pos.sin() * FRAC_1_SQRT_2,
                         -FRAC_1_SQRT_2,
-                    ].into(),
+                    ]
+                    .into(),
                 }
             }
             VertexSection::BottomRadius(i) => {
@@ -99,6 +101,10 @@ impl Cone {
 impl Iterator for Cone {
     type Item = Triangle<Vertex>;
 
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len(), Some(self.len()))
+    }
+
     fn next(&mut self) -> Option<Self::Item> {
         if self.u < self.sub_u * 2 {
             let idx = self.u;
@@ -110,6 +116,12 @@ impl Iterator for Cone {
         } else {
             None
         }
+    }
+}
+
+impl ExactSizeIterator for Cone {
+    fn len(&self) -> usize {
+        self.sub_u * 2
     }
 }
 
@@ -153,5 +165,18 @@ impl IndexedPolygon<Triangle<usize>> for Cone {
         // a face for every subdivide on the top, and one for every
         // subdivide around the bottom circle.
         self.sub_u * 2
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cone() {
+        let cone = Cone::new(8);
+        assert_eq!((16, Some(16)), cone.size_hint());
+        assert_eq!(25, cone.shared_vertex_count());
+        assert_eq!(16, cone.indexed_polygon_count());
     }
 }

--- a/src/cube.rs
+++ b/src/cube.rs
@@ -91,3 +91,12 @@ impl IndexedPolygon<Quad<usize>> for Cube {
         6
     }
 }
+
+#[test]
+fn test_cube_len() {
+    let mut cube = Cube::new();
+    assert_eq!(6, cube.len());
+    cube.next();
+    assert_eq!(5, cube.len());
+    assert_eq!(5, cube.count());
+}

--- a/src/cube.rs
+++ b/src/cube.rs
@@ -55,6 +55,12 @@ impl Iterator for Cube {
     }
 }
 
+impl ExactSizeIterator for Cube {
+    fn len(&self) -> usize {
+        self.range.len()
+    }
+}
+
 impl SharedVertex<Vertex> for Cube {
     fn shared_vertex(&self, idx: usize) -> Vertex {
         let (no, quad) = self.face_indexed(idx / 4);

--- a/src/cylinder.rs
+++ b/src/cylinder.rs
@@ -181,3 +181,12 @@ impl IndexedPolygon<Polygon<usize>> for Cylinder {
         (2 + self.sub_h) as usize * self.sub_u
     }
 }
+
+#[test]
+fn test_cylinder_len() {
+    let mut cylinder = Cylinder::new(5);
+    assert_eq!(15, cylinder.len());
+    cylinder.next();
+    assert_eq!(14, cylinder.len());
+    assert_eq!(14, cylinder.count());
+}

--- a/src/cylinder.rs
+++ b/src/cylinder.rs
@@ -122,8 +122,13 @@ impl Iterator for Cylinder {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let n = self.sub_u * (1 + self.sub_h - self.h) as usize - self.u;
-        (n, Some(n))
+        (self.len(), Some(self.len()))
+    }
+}
+
+impl ExactSizeIterator for Cylinder {
+    fn len(&self) -> usize {
+        self.sub_u * (1 + self.sub_h - self.h) as usize - self.u
     }
 }
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -41,6 +41,12 @@ impl<'a, T: SharedVertex<V>, V> Iterator for SharedVertexIterator<'a, T, V> {
     }
 }
 
+impl<'a, T: SharedVertex<V>, V> ExactSizeIterator for SharedVertexIterator<'a, T, V> {
+    fn len(&self) -> usize {
+        self.idx.len()
+    }
+}
+
 /// The `IndexedPolygon` trait is used with the `SharedVertex` trait in order to build
 /// a mesh. `IndexedPolygon` calculates each polygon face required to build an implementors mesh.
 /// each face is always returned in indexed form that points to the correct vertice supplied
@@ -78,5 +84,11 @@ impl<'a, T: IndexedPolygon<V>, V> Iterator for IndexedPolygonIterator<'a, T, V> 
 
     fn next(&mut self) -> Option<V> {
         self.idx.next().map(|idx| self.base.indexed_polygon(idx))
+    }
+}
+
+impl<'a, T: IndexedPolygon<V>, V> ExactSizeIterator for IndexedPolygonIterator<'a, T, V> {
+    fn len(&self) -> usize {
+        self.idx.len()
     }
 }

--- a/src/icosphere.rs
+++ b/src/icosphere.rs
@@ -196,3 +196,12 @@ impl IndexedPolygon<Triangle<usize>> for IcoSphere {
         Triangle::new(self.faces[idx][0], self.faces[idx][1], self.faces[idx][2])
     }
 }
+
+#[test]
+fn test_icosphere_len() {
+    let mut ico = IcoSphere::new();
+    assert_eq!(20, ico.len());
+    ico.next();
+    assert_eq!(19, ico.len());
+    assert_eq!(19, ico.count());
+}

--- a/src/icosphere.rs
+++ b/src/icosphere.rs
@@ -153,7 +153,7 @@ impl Iterator for IcoSphere {
     type Item = Triangle<Vertex>;
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.faces.len(), Some(self.faces.len()))
+        (self.len(), Some(self.len()))
     }
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -168,6 +168,12 @@ impl Iterator for IcoSphere {
         self.i += 1;
 
         Some(Triangle::new(x, y, z))
+    }
+}
+
+impl ExactSizeIterator for IcoSphere {
+    fn len(&self) -> usize {
+        self.faces.len() - self.i
     }
 }
 

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -70,8 +70,13 @@ impl Iterator for Plane {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let n = (self.subdivide_y - self.y) * self.subdivide_x + (self.subdivide_x - self.x);
-        (n, Some(n))
+        (self.len(), Some(self.len()))
+    }
+}
+
+impl ExactSizeIterator for Plane {
+    fn len(&self) -> usize {
+        (self.subdivide_y - self.y - 1) * self.subdivide_x + (self.subdivide_x - self.x)
     }
 }
 
@@ -120,4 +125,13 @@ fn test_shared_vertex_count() {
     let plane = Plane::subdivide(4, 4);
     assert_eq!(plane.shared_vertex_count(), 25);
     assert_eq!(plane.indexed_polygon_count(), 16);
+}
+
+#[test]
+fn test_plane_len() {
+    let mut plane = Plane::subdivide(2, 2);
+    assert_eq!(4, plane.len());
+    plane.next();
+    assert_eq!(3, plane.len());
+    assert_eq!(3, plane.count());
 }

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -138,3 +138,12 @@ impl IndexedPolygon<Polygon<usize>> for SphereUv {
         self.sub_v * self.sub_u
     }
 }
+
+#[test]
+fn test_sphere_len() {
+    let mut sphere = SphereUv::new(5, 5);
+    assert_eq!(25, sphere.len());
+    sphere.next();
+    assert_eq!(24, sphere.len());
+    assert_eq!(24, sphere.count());
+}

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -74,8 +74,13 @@ impl Iterator for SphereUv {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let n = (self.sub_v - self.v) * self.sub_u + (self.sub_u - self.u);
-        (n, Some(n))
+        (self.len(), Some(self.len()))
+    }
+}
+
+impl ExactSizeIterator for SphereUv {
+    fn len(&self) -> usize {
+        (self.sub_v - self.v - 1) * self.sub_u + (self.sub_u - self.u)
     }
 }
 

--- a/src/torus.rs
+++ b/src/torus.rs
@@ -42,6 +42,10 @@ impl Torus {
 impl Iterator for Torus {
     type Item = Quad<Vertex>;
 
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len(), Some(self.len()))
+    }
+
     fn next(&mut self) -> Option<Self::Item> {
         if self.idx < self.indexed_polygon_count() {
             let idx = self.idx;
@@ -53,6 +57,12 @@ impl Iterator for Torus {
         } else {
             None
         }
+    }
+}
+
+impl ExactSizeIterator for Torus {
+    fn len(&self) -> usize {
+        self.indexed_polygon_count() - self.idx
     }
 }
 
@@ -71,13 +81,15 @@ impl SharedVertex<Vertex> for Torus {
                 gamma * beta.cos(),
                 self.tubular_radius * alpha.sin(),
                 -gamma * beta.sin(),
-            ].into(),
+            ]
+            .into(),
             normal: Vector3::new(
                 alpha.cos() * beta.cos(),
                 alpha.sin(),
                 -alpha.cos() * beta.sin(),
-            ).normalize()
-                .into(),
+            )
+            .normalize()
+            .into(),
         }
     }
 

--- a/src/torus.rs
+++ b/src/torus.rs
@@ -122,3 +122,12 @@ impl IndexedPolygon<Quad<usize>> for Torus {
         self.tubular_segments * self.radial_segments
     }
 }
+
+#[test]
+fn test_torus_len() {
+    let mut torus = Torus::new(2.0, 2.0, 6, 5);
+    assert_eq!(30, torus.len());
+    torus.next();
+    assert_eq!(29, torus.len());
+    assert_eq!(29, torus.count());
+}


### PR DESCRIPTION
Tried tackling #58 but I wasn't able to figure out a way to actually implement what was being talked about in the issue for now, though while I was at it I did implement `ExactSizeIterator` for a lot of other simpler iterators if that change is welcome. I also found a few `size_hints` that seemed to be incorrect or wouldn't track the iterators progressions.