### PR TITLE
Remove the cgmath dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 description = "A package for generating 3D meshes"
 homepage = "https://github.com/gfx-rs/genmesh"
 repository = "https://github.com/gfx-rs/genmesh"
+edition = "2018"
 
 [lib]
 name = "genmesh"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,7 @@ name = "genmesh"
 path = "src/lib.rs"
 
 [dependencies]
-cgmath = { version = "0.17", features = ["mint"] }
 mint = "0.5"
+
+[dev-dependencies]
+cgmath = { version = "0.17" }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -18,7 +18,7 @@ extern crate genmesh;
 extern crate test;
 
 use genmesh::generators::{IndexedPolygon, SharedVertex};
-use genmesh::generators::{Plane, SphereUV};
+use genmesh::generators::{Plane, SphereUv};
 use genmesh::*;
 use test::{black_box, Bencher};
 
@@ -98,7 +98,7 @@ fn plane_256x256_index_triangulate(bench: &mut Bencher) {
 #[bench]
 fn sphere_16x16_index(bench: &mut Bencher) {
     bench.iter(|| {
-        let plane = SphereUV::new(16, 16);
+        let plane = SphereUv::new(16, 16);
         for i in plane.indexed_polygon_iter() {
             black_box(i);
         }
@@ -108,7 +108,7 @@ fn sphere_16x16_index(bench: &mut Bencher) {
 #[bench]
 fn sphere_256x256_index(bench: &mut Bencher) {
     bench.iter(|| {
-        let plane = SphereUV::new(256, 256);
+        let plane = SphereUv::new(256, 256);
         for i in plane.indexed_polygon_iter() {
             black_box(i);
         }
@@ -118,7 +118,7 @@ fn sphere_256x256_index(bench: &mut Bencher) {
 #[bench]
 fn sphere_16x16_vertex(bench: &mut Bencher) {
     bench.iter(|| {
-        let plane = SphereUV::new(16, 16);
+        let plane = SphereUv::new(16, 16);
         for i in plane.shared_vertex_iter() {
             black_box(i);
         }
@@ -128,7 +128,7 @@ fn sphere_16x16_vertex(bench: &mut Bencher) {
 #[bench]
 fn sphere_256x256_vertex(bench: &mut Bencher) {
     bench.iter(|| {
-        let plane = SphereUV::new(256, 256);
+        let plane = SphereUv::new(256, 256);
         for i in plane.shared_vertex_iter() {
             black_box(i);
         }
@@ -138,7 +138,7 @@ fn sphere_256x256_vertex(bench: &mut Bencher) {
 #[bench]
 fn sphere_16x16_index_triangulate(bench: &mut Bencher) {
     bench.iter(|| {
-        let plane = SphereUV::new(16, 16);
+        let plane = SphereUv::new(16, 16);
         for i in plane.indexed_polygon_iter().triangulate() {
             black_box(i);
         }
@@ -148,7 +148,7 @@ fn sphere_16x16_index_triangulate(bench: &mut Bencher) {
 #[bench]
 fn sphere_256x256_index_triangulate(bench: &mut Bencher) {
     bench.iter(|| {
-        let plane = SphereUV::new(256, 256);
+        let plane = SphereUv::new(256, 256);
         for i in plane.indexed_polygon_iter().triangulate() {
             black_box(i);
         }

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -1,8 +1,8 @@
-use super::generators::{IndexedPolygon, SharedVertex};
-use super::Polygon::PolyTri;
-use super::{Polygon, Triangle};
 use std::f32::consts::PI;
-use Vertex;
+
+use crate::generators::{IndexedPolygon, SharedVertex};
+use crate::Polygon::{self, PolyTri};
+use crate::{Triangle, Vertex};
 
 /// Represents a circle in the XY plane with radius of 1, centered at (0, 0, 0)
 #[derive(Clone, Copy)]

--- a/src/circle.rs
+++ b/src/circle.rs
@@ -45,22 +45,25 @@ impl Iterator for Circle {
     }
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.u > self.sub_u {
-            None
-        } else if self.u == self.sub_u {
-            self.u += 1;
-            Some(PolyTri(Triangle::new(
-                self.vert(0),
-                self.vert(self.u - 1),
-                self.vert(1),
-            )))
-        } else {
-            self.u += 1;
-            Some(PolyTri(Triangle::new(
-                self.vert(0),
-                self.vert(self.u - 1),
-                self.vert(self.u),
-            )))
+        use std::cmp::Ordering;
+        match self.u.cmp(&self.sub_u) {
+            Ordering::Less => {
+                self.u += 1;
+                Some(PolyTri(Triangle::new(
+                    self.vert(0),
+                    self.vert(self.u - 1),
+                    self.vert(self.u),
+                )))
+            }
+            Ordering::Equal => {
+                self.u += 1;
+                Some(PolyTri(Triangle::new(
+                    self.vert(0),
+                    self.vert(self.u - 1),
+                    self.vert(1),
+                )))
+            }
+            Ordering::Greater => None,
         }
     }
 }
@@ -104,6 +107,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(clippy::approx_constant)]
     fn test_circle() {
         let circle = Circle::new(8);
         assert_eq!((8, Some(8)), circle.size_hint());

--- a/src/cube.rs
+++ b/src/cube.rs
@@ -1,7 +1,7 @@
-use super::generators::{IndexedPolygon, SharedVertex};
-use super::{MapVertex, Quad};
 use std::ops::Range;
-use {Normal, Position, Vertex};
+
+use crate::generators::{IndexedPolygon, SharedVertex};
+use crate::{MapVertex, Normal, Position, Quad, Vertex};
 
 /// A perfect cube, centered at (0, 0, 0) with each face starting at 1/-1 away from the origin
 #[derive(Clone)]

--- a/src/cube.rs
+++ b/src/cube.rs
@@ -43,6 +43,12 @@ impl Cube {
     }
 }
 
+impl Default for Cube {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Iterator for Cube {
     type Item = Quad<Vertex>;
 

--- a/src/cylinder.rs
+++ b/src/cylinder.rs
@@ -1,7 +1,6 @@
-use super::generators::{IndexedPolygon, SharedVertex};
-use super::{Polygon, Quad, Triangle};
+use crate::generators::{IndexedPolygon, SharedVertex};
+use crate::{Normal, Polygon, Position, Quad, Triangle, Vertex};
 use std::f32::consts::PI;
-use {Normal, Position, Vertex};
 
 /// Represents a cylinder with radius of 1, height of 2,
 /// and centered at (0, 0, 0) pointing up (to 0, 0, 1).

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -13,7 +13,7 @@ pub trait SharedVertex<V>: Sized {
 
     /// create an iterator that returns each shared vertex that is required to
     /// build the mesh.
-    fn shared_vertex_iter<'a>(&'a self) -> SharedVertexIterator<'a, Self, V> {
+    fn shared_vertex_iter(&self) -> SharedVertexIterator<Self, V> {
         SharedVertexIterator {
             base: self,
             idx: 0..self.shared_vertex_count(),
@@ -59,7 +59,7 @@ pub trait IndexedPolygon<V>: Sized {
     fn indexed_polygon_count(&self) -> usize;
 
     /// create a iterator that will return a polygon for each face in the source mesh
-    fn indexed_polygon_iter<'a>(&'a self) -> IndexedPolygonIterator<'a, Self, V> {
+    fn indexed_polygon_iter(&self) -> IndexedPolygonIterator<Self, V> {
         IndexedPolygonIterator {
             base: self,
             idx: 0..self.indexed_polygon_count(),

--- a/src/icosphere.rs
+++ b/src/icosphere.rs
@@ -113,6 +113,12 @@ impl IcoSphere {
     }
 }
 
+impl Default for IcoSphere {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 fn subdivide_impl(
     mut vertices: Vec<[f32; 3]>,
     faces: Vec<[usize; 3]>,

--- a/src/icosphere.rs
+++ b/src/icosphere.rs
@@ -2,10 +2,8 @@
 
 use std::collections::HashMap;
 
-use cgmath::{InnerSpace, Vector3};
-
 use crate::generators::{IndexedPolygon, SharedVertex};
-use crate::{Triangle, Vertex};
+use crate::{math::Vector3, Triangle, Vertex};
 
 /// Icosahedral sphere with radius 1, centered at (0., 0., 0.)
 #[derive(Clone, Debug)]
@@ -151,7 +149,7 @@ fn subdivide_impl(
 
 fn new_point(start: [f32; 3], end: [f32; 3]) -> [f32; 3] {
     Vector3::new(start[0] + end[0], start[1] + end[1], start[2] + end[2])
-        .normalize()
+        .normalized()
         .into()
 }
 

--- a/src/icosphere.rs
+++ b/src/icosphere.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 
 use cgmath::{InnerSpace, Vector3};
 
-use generators::{IndexedPolygon, SharedVertex};
-use {Triangle, Vertex};
+use crate::generators::{IndexedPolygon, SharedVertex};
+use crate::{Triangle, Vertex};
 
 /// Icosahedral sphere with radius 1, centered at (0., 0., 0.)
 #[derive(Clone, Debug)]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -31,7 +31,7 @@ impl<T, F: FnMut(usize, T)> LruIndexer<T, F> {
             index: 0,
             max: size,
             cache: Vec::new(),
-            emit: emit,
+            emit,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,10 @@
 extern crate cgmath;
 extern crate mint;
 
-pub use poly::{EmitLines, Line, Lines, MapToVertices, MapVertex, Polygon, Quad, Triangle,
-               Vertices, VerticesIterator};
+pub use poly::{
+    EmitLines, Line, Lines, MapToVertices, MapVertex, Polygon, Quad, Triangle, Vertices,
+    VerticesIterator,
+};
 
 pub use triangulate::{EmitTriangles, Triangulate, TriangulateIterator};
 
@@ -48,7 +50,9 @@ pub mod generators {
     pub use cone::Cone;
     pub use cube::Cube;
     pub use cylinder::Cylinder;
-    pub use generator::{IndexedPolygon, IndexedPolygonIterator, SharedVertex, SharedVertexIterator};
+    pub use generator::{
+        IndexedPolygon, IndexedPolygonIterator, SharedVertex, SharedVertexIterator,
+    };
     pub use icosphere::IcoSphere;
     pub use plane::Plane;
     pub use sphere::SphereUv;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,6 @@
 #![deny(missing_docs)]
 #![allow(clippy::many_single_char_names)]
 
-extern crate cgmath;
-extern crate mint;
-
 pub use poly::{
     EmitLines, Line, Lines, MapToVertices, MapVertex, Polygon, Quad, Triangle, Vertices,
     VerticesIterator,
@@ -28,6 +25,8 @@ pub use triangulate::{EmitTriangles, Triangulate, TriangulateIterator};
 pub use indexer::{Indexer, LruIndexer};
 
 pub use neighbors::Neighbors;
+
+mod math;
 
 mod generator;
 mod indexer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 //! needs.
 
 #![deny(missing_docs)]
+#![allow(clippy::many_single_char_names)]
 
 extern crate cgmath;
 extern crate mint;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,17 +46,17 @@ mod torus;
 /// A collection of utilties that can be used to build
 /// meshes programmatically.
 pub mod generators {
-    pub use circle::Circle;
-    pub use cone::Cone;
-    pub use cube::Cube;
-    pub use cylinder::Cylinder;
-    pub use generator::{
+    pub use super::circle::Circle;
+    pub use super::cone::Cone;
+    pub use super::cube::Cube;
+    pub use super::cylinder::Cylinder;
+    pub use super::generator::{
         IndexedPolygon, IndexedPolygonIterator, SharedVertex, SharedVertexIterator,
     };
-    pub use icosphere::IcoSphere;
-    pub use plane::Plane;
-    pub use sphere::SphereUv;
-    pub use torus::Torus;
+    pub use super::icosphere::IcoSphere;
+    pub use super::plane::Plane;
+    pub use super::sphere::SphereUv;
+    pub use super::torus::Torus;
 }
 
 /// Common vertex position type.

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,0 +1,78 @@
+use std::ops;
+
+#[derive(Copy, Clone, Debug)]
+pub struct Vector3 {
+    x: f32,
+    y: f32,
+    z: f32,
+}
+
+impl Vector3 {
+    #[inline]
+    pub fn new(x: f32, y: f32, z: f32) -> Self {
+        Vector3 { x, y, z }
+    }
+
+    #[inline]
+    pub fn magnitude_squared(self) -> f32 {
+        self.x * self.x + self.y * self.y + self.z * self.z
+    }
+
+    #[inline]
+    pub fn magnitude(self) -> f32 {
+        self.magnitude_squared().sqrt()
+    }
+
+    #[inline]
+    pub fn normalized(self) -> Vector3 {
+        let mag = self.magnitude();
+        Vector3::new(self.x / mag, self.y / mag, self.z / mag)
+    }
+
+    #[inline]
+    pub fn cross(self, Vector3 { x, y, z }: Vector3) -> Vector3 {
+        Vector3::new(
+            self.x.mul_add(z, -self.z * y),
+            self.y.mul_add(x, -self.x * z),
+            self.z.mul_add(y, -self.y * x),
+        )
+    }
+}
+
+impl From<Vector3> for [f32; 3] {
+    #[inline]
+    fn from(Vector3 { x, y, z }: Vector3) -> Self {
+        [x, y, z]
+    }
+}
+
+impl From<mint::Vector3<f32>> for Vector3 {
+    #[inline]
+    fn from(mint::Vector3 { x, y, z }: mint::Vector3<f32>) -> Self {
+        Vector3 { x, y, z }
+    }
+}
+
+impl From<Vector3> for mint::Vector3<f32> {
+    #[inline]
+    fn from(Vector3 { x, y, z }: Vector3) -> Self {
+        mint::Vector3 { x, y, z }
+    }
+}
+
+impl ops::Sub for Vector3 {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, Vector3 { x, y, z }: Self) -> Self::Output {
+        Vector3::new(self.x - x, self.y - y, self.z - z)
+    }
+}
+
+impl ops::AddAssign for Vector3 {
+    fn add_assign(&mut self, Vector3 { x, y, z }: Self) {
+        self.x += x;
+        self.y += y;
+        self.z += z;
+    }
+}

--- a/src/neighbors.rs
+++ b/src/neighbors.rs
@@ -26,23 +26,17 @@ impl<T> Neighbors<T> {
 
         for (i, p) in polygons.iter().enumerate() {
             p.clone().emit_lines(|line| {
-                shares_vertex
-                    .entry(line.x.clone())
-                    .or_insert(Vec::new())
-                    .push(i);
-                shares_vertex
-                    .entry(line.y.clone())
-                    .or_insert(Vec::new())
-                    .push(i);
-                shares_edge.entry(line).or_insert(Vec::new()).push(i);
+                shares_vertex.entry(line.x).or_insert_with(Vec::new).push(i);
+                shares_vertex.entry(line.y).or_insert_with(Vec::new).push(i);
+                shares_edge.entry(line).or_insert_with(Vec::new).push(i);
             });
         }
 
         Neighbors {
-            vertices: vertices,
-            shares_vertex: shares_vertex,
-            shares_edge: shares_edge,
-            polygons: polygons,
+            vertices,
+            shares_vertex,
+            shares_edge,
+            polygons,
         }
     }
 
@@ -64,11 +58,11 @@ impl<T> Neighbors<T> {
         self.polygons.get(i).map(|x| {
             let mut v = HashSet::new();
             x.clone().emit_lines(|line| {
-                self.shares_edge.get(&line).map(|x| {
+                if let Some(x) = self.shares_edge.get(&line) {
                     for &i in x {
                         v.insert(i);
                     }
-                });
+                }
             });
             v.remove(&i);
             v

--- a/src/neighbors.rs
+++ b/src/neighbors.rs
@@ -4,8 +4,8 @@
 use cgmath::{InnerSpace, Vector3};
 use std::collections::{HashMap, HashSet};
 
-use poly::{EmitLines, Line, Triangle};
-use Normal;
+use crate::poly::{EmitLines, Line, Triangle};
+use crate::Normal;
 
 /// Neighbors search accelerating structure.
 pub struct Neighbors<T> {

--- a/src/neighbors.rs
+++ b/src/neighbors.rs
@@ -1,11 +1,10 @@
 //! This is a utility to search out and work in the mesh as a whole rather
 //! then polygon by polygon.
 
-use cgmath::{InnerSpace, Vector3};
 use std::collections::{HashMap, HashSet};
 
 use crate::poly::{EmitLines, Line, Triangle};
-use crate::Normal;
+use crate::{math::Vector3, Normal};
 
 /// Neighbors search accelerating structure.
 pub struct Neighbors<T> {
@@ -86,7 +85,7 @@ impl<T> Neighbors<T> {
         let a = z - x;
         let b = z - y;
 
-        a.cross(b).normalize().into()
+        a.cross(b).normalized().into()
     }
 
     /// Calculate the normal for an vertex based on the average
@@ -104,6 +103,6 @@ impl<T> Neighbors<T> {
             normal += Vector3::from(self.normal_for_face(face, &mut f));
         }
 
-        normal.normalize().into()
+        normal.normalized().into()
     }
 }

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -1,6 +1,5 @@
 use super::generators::{IndexedPolygon, SharedVertex};
-use super::Quad;
-use Vertex;
+use super::{Quad, Vertex};
 
 /// Represents a 2D plane with origin of (0, 0), from 1 to -1
 #[derive(Clone, Copy)]

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -47,6 +47,12 @@ impl Plane {
     }
 }
 
+impl Default for Plane {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Iterator for Plane {
     type Item = Quad<Vertex>;
 

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -64,7 +64,7 @@ pub trait EmitVertices<T> {
     /// Consume a polygon, each
     /// vertex is emitted to the parent function by calling the supplied
     /// lambda function
-    fn emit_vertices<F>(self, F)
+    fn emit_vertices<F>(self, f: F)
     where
         F: FnMut(T);
 }
@@ -167,7 +167,7 @@ pub trait MapVertex<T, U> {
     /// It's internal values should reflect any transformation the map did.
     type Output;
     /// map a function to each vertex in polygon creating a new polygon
-    fn map_vertex<F>(self, F) -> Self::Output
+    fn map_vertex<F>(self, f: F) -> Self::Output
     where
         F: FnMut(T) -> U;
 }

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -148,15 +148,13 @@ impl<V, U: EmitVertices<V>, SRC: Iterator<Item = U>> Iterator for VerticesIterat
 
     fn next(&mut self) -> Option<V> {
         loop {
-            match self.buffer.pop_front() {
-                Some(v) => return Some(v),
-                None => (),
+            if let v @ Some(_) = self.buffer.pop_front() {
+                break v;
             }
 
-            match self.source.next() {
-                Some(p) => p.emit_vertices(|v| self.buffer.push_back(v)),
-                None => return None,
-            }
+            self.source
+                .next()?
+                .emit_vertices(|v| self.buffer.push_back(v));
         }
     }
 }
@@ -308,7 +306,7 @@ pub struct Line<T> {
 impl<T> Line<T> {
     /// Create a new line using point x and y
     pub fn new(x: T, y: T) -> Self {
-        Line { x: x, y: y }
+        Line { x, y }
     }
 }
 
@@ -410,15 +408,11 @@ where
 
     fn next(&mut self) -> Option<Line<V>> {
         loop {
-            match self.buffer.pop_front() {
-                Some(v) => return Some(v),
-                None => (),
+            if let v @ Some(_) = self.buffer.pop_front() {
+                break v;
             }
 
-            match self.source.next() {
-                Some(p) => p.emit_lines(|v| self.buffer.push_back(v)),
-                None => return None,
-            }
+            self.source.next()?.emit_lines(|v| self.buffer.push_back(v));
         }
     }
 }

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -1,8 +1,8 @@
-use super::generators::{IndexedPolygon, SharedVertex};
-use super::Polygon::{PolyQuad, PolyTri};
-use super::{Polygon, Quad, Triangle};
 use std::f32::consts::PI;
-use Vertex;
+
+use crate::generators::{IndexedPolygon, SharedVertex};
+use crate::Polygon::{self, PolyQuad, PolyTri};
+use crate::{Quad, Triangle, Vertex};
 
 /// Represents a sphere with radius of 1, centered at (0, 0, 0)
 #[derive(Clone, Copy)]

--- a/src/torus.rs
+++ b/src/torus.rs
@@ -1,9 +1,8 @@
 use std::f32::consts::PI;
 
-use cgmath::{InnerSpace, Vector3};
-
 use super::generators::{IndexedPolygon, SharedVertex};
 use super::{MapVertex, Quad, Vertex};
+use crate::math::Vector3;
 
 ///
 #[derive(Clone, Copy)]
@@ -88,7 +87,7 @@ impl SharedVertex<Vertex> for Torus {
                 alpha.sin(),
                 -alpha.cos() * beta.sin(),
             )
-            .normalize()
+            .normalized()
             .into(),
         }
     }

--- a/src/triangulate.rs
+++ b/src/triangulate.rs
@@ -52,8 +52,8 @@ impl<T: Clone> EmitTriangles for Polygon<T> {
         F: FnMut(Triangle<T>),
     {
         match self {
-            &PolyTri(ref t) => t.emit_triangles(emit),
-            &PolyQuad(ref q) => q.emit_triangles(emit),
+            PolyTri(t) => t.emit_triangles(emit),
+            PolyQuad(q) => q.emit_triangles(emit),
         }
     }
 }
@@ -99,15 +99,13 @@ impl<V, U: EmitTriangles<Vertex = V>, SRC: Iterator<Item = U>> Iterator
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            match self.buffer.pop_front() {
-                Some(v) => return Some(v),
-                None => (),
+            if let v @ Some(_) = self.buffer.pop_front() {
+                break v;
             }
 
-            match self.source.next() {
-                Some(p) => p.emit_triangles(|v| self.buffer.push_back(v)),
-                None => return None,
-            }
+            self.source
+                .next()?
+                .emit_triangles(|v| self.buffer.push_back(v));
         }
     }
 }

--- a/src/triangulate.rs
+++ b/src/triangulate.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 
-use Polygon::{PolyQuad, PolyTri};
-use {Polygon, Quad, Triangle};
+use crate::Polygon::{self, PolyQuad, PolyTri};
+use crate::{Quad, Triangle};
 
 /// provides a way to convert a polygon down to triangles
 pub trait EmitTriangles {
@@ -10,7 +10,7 @@ pub trait EmitTriangles {
 
     /// convert a polygon to one or more triangles, each triangle
     /// is returned by calling `emit`
-    fn emit_triangles<F>(&self, F)
+    fn emit_triangles<F>(&self, f: F)
     where
         F: FnMut(Triangle<Self::Vertex>);
 }

--- a/tests/generate.rs
+++ b/tests/generate.rs
@@ -1,6 +1,3 @@
-extern crate cgmath;
-extern crate genmesh;
-
 use genmesh::{generators, EmitTriangles, MapVertex, Triangulate};
 use std::fmt::Debug;
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,7 +1,9 @@
 extern crate genmesh;
 
-use genmesh::{EmitTriangles, Indexer, LruIndexer, MapToVertices, Quad, Triangle, Triangulate,
-              Vertex, Vertices};
+use genmesh::{
+    EmitTriangles, Indexer, LruIndexer, MapToVertices, Quad, Triangle, Triangulate, Vertex,
+    Vertices,
+};
 
 use genmesh::generators::Plane;
 
@@ -14,9 +16,9 @@ fn quad_vertex() {
         Quad::new(true, false, true, false),
     ];
 
-    let transformed = input.iter().map(|x| x.clone()).vertex(|v| v % 2 != 0);
+    let transformed = input.iter().cloned().vertex(|v| v % 2 != 0);
 
-    for (x, y) in transformed.zip(output.iter().map(|x| x.clone())) {
+    for (x, y) in transformed.zip(output.iter().cloned()) {
         assert_eq!(x, y);
     }
 }
@@ -32,11 +34,11 @@ fn quad_vertex_two_stages() {
 
     let transformed = input
         .iter()
-        .map(|x| x.clone())
+        .cloned()
         .vertex(|v| v as u8)
         .vertex(|v| v % 2 != 0);
 
-    for (x, y) in transformed.zip(output.iter().map(|x| x.clone())) {
+    for (x, y) in transformed.zip(output.iter().cloned()) {
         assert_eq!(x, y);
     }
 }
@@ -49,10 +51,10 @@ fn quad_poly_simple() {
 
     let transformed = input
         .iter()
-        .map(|x| x.clone())
+        .cloned()
         .map(|v| Quad::new(0isize, v.y as isize, v.z as isize, 0));
 
-    for (x, y) in transformed.zip(output.iter().map(|x| x.clone())) {
+    for (x, y) in transformed.zip(output.iter().cloned()) {
         assert_eq!(x, y);
     }
 }
@@ -66,9 +68,9 @@ fn triangle_vertex() {
         Triangle::new(true, false, true),
     ];
 
-    let transformed = input.iter().map(|x| x.clone()).vertex(|v| v % 2 != 0);
+    let transformed = input.iter().cloned().vertex(|v| v % 2 != 0);
 
-    for (x, y) in transformed.zip(output.iter().map(|x| x.clone())) {
+    for (x, y) in transformed.zip(output.iter().cloned()) {
         assert_eq!(x, y);
     }
 }
@@ -84,11 +86,11 @@ fn triangle_vertex_two_stages() {
 
     let transformed = input
         .iter()
-        .map(|x| x.clone())
+        .cloned()
         .vertex(|v| v as u8)
         .vertex(|v| v % 2 != 0);
 
-    for (x, y) in transformed.zip(output.iter().map(|x| x.clone())) {
+    for (x, y) in transformed.zip(output.iter().cloned()) {
         assert_eq!(x, y);
     }
 }
@@ -101,10 +103,10 @@ fn triangle_poly_simple() {
 
     let transformed = input
         .iter()
-        .map(|x| x.clone())
+        .cloned()
         .map(|v| Triangle::new(0isize, v.y as isize, v.z as isize));
 
-    for (x, y) in transformed.zip(output.iter().map(|x| x.clone())) {
+    for (x, y) in transformed.zip(output.iter().cloned()) {
         assert_eq!(x, y);
     }
 }
@@ -194,7 +196,7 @@ fn emit_lines() {
     assert_eq!(Line::new(3, 0), lines[3]);
 
     let quads = [Quad::new(0i8, 1, 2, 3), Quad::new(4i8, 5, 6, 7)];
-    let lines: Vec<Line<i8>> = quads.iter().map(|&x| x).lines().collect();
+    let lines: Vec<Line<i8>> = quads.iter().copied().lines().collect();
 
     assert_eq!(8, lines.len());
     assert_eq!(Line::new(0, 1), lines[0]);

--- a/tests/winding.rs
+++ b/tests/winding.rs
@@ -1,6 +1,3 @@
-extern crate cgmath;
-extern crate genmesh;
-
 use std::collections::HashSet;
 
 use cgmath::InnerSpace;

--- a/tests/winding.rs
+++ b/tests/winding.rs
@@ -98,7 +98,7 @@ where
     // this means that there is no polygon who's neighbor switches winding
     // direction, but it does not mean that the polygon is correct. They
     // all could be backwards. So this still requires a secondary inspection.
-    assert!(lines.len() == 0);
+    assert_eq!(lines.len(), 0);
 }
 
 #[test]


### PR DESCRIPTION
This builds on the changes in #68 and would be a fix for #65. Simply put it turns `cgmath` into a dev dependency since its used there and I didn't reexport the manual math to the public. I simply put this change together as removing cgmath was only roughly 100 lines since only `Vector3` was being used a few times.