### PR TITLE
Improve documentation and reexport missing public items in `poly`

### DIFF
--- a/src/circle.rs
+++ b/src/circle.rs
@@ -12,8 +12,15 @@ pub struct Circle {
 }
 
 impl Circle {
-    /// Create a new sphere.
-    /// `u` is the number of points around the circle, must be > 3
+    /// Creates a new sphere.
+    ///
+    /// # Arguments
+    ///
+    /// - `u` is the number of points around the circle, it must be at least 4
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `u` is less than 4.
     pub fn new(u: usize) -> Self {
         assert!(u > 3);
         Circle { u: 1, sub_u: u }

--- a/src/cone.rs
+++ b/src/cone.rs
@@ -13,25 +13,31 @@ enum VertexSection {
     BottomCenter,
 }
 
-/// The `Cone` mesh will create a mesh that is from 1 to -1
+/// The `Cone` mesh will create a mesh that goes from 1 to -1.
 /// The bottom will be a circle around [0, 0, -1] with a radius
-/// of 1, all coords on the bottom will follow the plan equation `-z-1=0`
-/// The tip of the cone will always be at coord [0, 0, 1]
+/// of 1, all coords on the bottom will follow the plane equation `-z-1=0`.
+/// The tip of the cone will always be at coord [0, 0, 1].
 pub struct Cone {
     u: usize,
     sub_u: usize,
 }
 
 impl Cone {
-    /// Creates a new `Cone`
-    /// `u` is the number of subdivisions around the radius of the cone
-    /// it must be greater then 1.
+    /// Creates a new cone.
+    ///
+    /// # Arguments
+    ///
+    /// - `u` is the number of subdivisions around the radius of the cone,
+    ///     it must be at least 2
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `u` is less than 2.
     pub fn new(u: usize) -> Self {
         assert!(u >= 2);
         Cone { u: 0, sub_u: u }
     }
 
-    ///
     fn vertex(&self, sec: VertexSection) -> Vertex {
         let divisions = TWO_PI / self.sub_u as f32;
 

--- a/src/cube.rs
+++ b/src/cube.rs
@@ -10,7 +10,7 @@ pub struct Cube {
 }
 
 impl Cube {
-    /// create a new cube generator
+    /// Creates a new cube.
     pub fn new() -> Self {
         Cube { range: 0..6 }
     }

--- a/src/cylinder.rs
+++ b/src/cylinder.rs
@@ -39,8 +39,15 @@ const BOT: Vertex = Vertex {
 };
 
 impl Cylinder {
-    /// Create a new cylinder.
-    /// `u` is the number of points across the radius.
+    /// Creates a new cylinder.
+    ///
+    /// # Arguments
+    ///
+    /// - `u` is the number of points across the radius, it must be at least 2
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `u` is less than 2.
     pub fn new(u: usize) -> Self {
         assert!(u > 1);
         Cylinder {
@@ -51,9 +58,16 @@ impl Cylinder {
         }
     }
 
-    /// Create a new subdivided cylinder.
-    /// `u` is the number of points across the radius.
-    /// `h` is the number of segments across the height.
+    /// Creates a new subdivided cylinder.
+    ///
+    /// # Arguments
+    ///
+    /// - `u` is the number of points across the radius, it must be at least 2
+    /// - `h` is the number of segments across the height, it must be non-zero
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `u` is less than 2 or if `h` is 0.
     pub fn subdivide(u: usize, h: usize) -> Self {
         assert!(u > 1 && h > 0);
         Cylinder {

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,17 +1,19 @@
 use std::marker::PhantomData;
 use std::ops::Range;
 
-/// The `SharedVertex` trait is meant to be used with the `IndexedPolygon` trait.
+/// The `SharedVertex` trait is meant to be used with the [`IndexedPolygon`] trait.
 /// This trait is meant as a way to calculate the shared vertices that are
 /// required to build the implementors mesh.
+///
+/// [`IndexedPolygon`]: trait.IndexedPolygon.html
 pub trait SharedVertex<V>: Sized {
-    /// return the shared vertex at offset `i`
+    /// Returns the shared vertex at offset `i`.
     fn shared_vertex(&self, i: usize) -> V;
 
-    /// return the number of shared vertices required to represent the mesh
+    /// Returns the number of shared vertices required to represent the mesh.
     fn shared_vertex_count(&self) -> usize;
 
-    /// create an iterator that returns each shared vertex that is required to
+    /// Create an [`Iterator`] that returns each shared vertex that is required to
     /// build the mesh.
     fn shared_vertex_iter(&self) -> SharedVertexIterator<Self, V> {
         SharedVertexIterator {
@@ -22,7 +24,12 @@ pub trait SharedVertex<V>: Sized {
     }
 }
 
-/// An iterator that yields the shared vertices of the mesh
+/// An [`Iterator`] that yields the shared vertices of the mesh.
+///
+/// This `struct` is created by the [`shared_vertex_iter`] method on [`SharedVertex`].
+///
+/// [`shared_vertex_iter`]: trait.SharedVertex.html#method.shared_vertex_iter
+/// [`SharedVertex`]: trait.SharedVertex.html
 pub struct SharedVertexIterator<'a, T: 'a, V> {
     base: &'a T,
     idx: Range<usize>,
@@ -47,18 +54,20 @@ impl<'a, T: SharedVertex<V>, V> ExactSizeIterator for SharedVertexIterator<'a, T
     }
 }
 
-/// The `IndexedPolygon` trait is used with the `SharedVertex` trait in order to build
+/// The `IndexedPolygon` trait is used with the [`SharedVertex`] trait in order to build
 /// a mesh. `IndexedPolygon` calculates each polygon face required to build an implementors mesh.
-/// each face is always returned in indexed form that points to the correct vertice supplied
-/// by the `SharedVertex` trait.
+/// Each face is always returned in indexed form that points to the correct vertice supplied
+/// by the [`SharedVertex`] trait.
+///
+/// [`SharedVertex`]: trait.SharedVertex.html
 pub trait IndexedPolygon<V>: Sized {
-    /// return a polygon with indices to the shared vertex
+    /// Returns a polygon with indices to the shared vertex.
     fn indexed_polygon(&self, i: usize) -> V;
 
-    /// return the number of polygons that are needed to represent this mesh
+    /// Returns the number of polygons that are needed to represent this mesh.
     fn indexed_polygon_count(&self) -> usize;
 
-    /// create a iterator that will return a polygon for each face in the source mesh
+    /// Creates an [`Iterator`] that will return a polygon for each face in the source mesh.
     fn indexed_polygon_iter(&self) -> IndexedPolygonIterator<Self, V> {
         IndexedPolygonIterator {
             base: self,
@@ -68,7 +77,12 @@ pub trait IndexedPolygon<V>: Sized {
     }
 }
 
-/// An iterator that yields the indices of the mesh
+/// An [`Iterator`] that yields the indices of the mesh
+///
+/// This `struct` is created by the [`indexed_polygon_iter`] method on [`IndexedPolygon`].
+///
+/// [`indexed_polygon_iter`]: trait.IndexedPolygon.html#method.indexed_polygon_iter
+/// [`IndexedPolygon`]: trait.IndexedPolygon.html
 pub struct IndexedPolygonIterator<'a, T: 'a, V> {
     base: &'a T,
     idx: Range<usize>,

--- a/src/icosphere.rs
+++ b/src/icosphere.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use crate::generators::{IndexedPolygon, SharedVertex};
 use crate::{math::Vector3, Triangle, Vertex};
 
-/// Icosahedral sphere with radius 1, centered at (0., 0., 0.)
+/// Icosahedral sphere with radius 1, centered at (0., 0., 0.).
 #[derive(Clone, Debug)]
 pub struct IcoSphere {
     i: usize,
@@ -71,7 +71,7 @@ const FACES: [[usize; 3]; 20] = [
 ];
 
 impl IcoSphere {
-    /// Create a unit sphere with 20 faces and 12 vertices.
+    /// Creates a unit sphere with 20 faces and 12 vertices.
     pub fn new() -> Self {
         Self {
             i: 0,
@@ -83,9 +83,9 @@ impl IcoSphere {
     /// Create a unit sphere with subdivision, resulting in 20 * 4^N faces, where N is the number of
     /// subdivisions.
     ///
-    /// ## Parameters
+    /// # Arguments
     ///
-    /// - `subdivides`: Number of subdivisions to perform.
+    /// - `subdivides` is the number of subdivisions to perform
     pub fn subdivide(subdivides: usize) -> Self {
         let mut vertices = VERTICES.to_vec();
         let mut faces = FACES.to_vec();

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,16 +1,16 @@
-/// A trait defining how to defined an Indexer. An indexer is a object
-/// that collects verticies and emits indexes for the vertex. The intent
-/// is that an Indexer can find redundent vertexes and deduplicate them
-/// by returning aliased indexes.
+/// A trait defining how to define an Indexer. An indexer is an object
+/// that collects vertices and emits indices for the given vertex. The intent
+/// is that an Indexer can find redundent vertices and deduplicate them
+/// by returning aliased indices.
 pub trait Indexer<T> {
-    /// convert a vertex into an index.
+    /// Converts a vertex into an index.
     fn index(&mut self, v: T) -> usize;
 }
 
-/// An `LruIndexer` is useful for creating indexed steam from a stream of
-/// vertices. Each vertex that is index is only compared against the vetices
-/// contained in the cache. If a vertex is not found the LruIndexer will `emit`
-/// a new vertex and return the index of that new vertex.
+/// An `LruIndexer` is useful for creating an indexed steam from a stream of
+/// vertices. Each vertex that is indexed is only being compared against the
+/// vertices which are contained in the cache. If a vertex is not found, the
+/// LruIndexer will `emit` a new vertex and return the index of that new vertex.
 ///
 /// The oldest sample by time used will be dropped if a new vertex is found.
 pub struct LruIndexer<T, F: FnMut(usize, T)> {
@@ -21,11 +21,11 @@ pub struct LruIndexer<T, F: FnMut(usize, T)> {
 }
 
 impl<T, F: FnMut(usize, T)> LruIndexer<T, F> {
-    /// create a new `LruIndexer`, the window size is limited by the `size` parameter
-    /// it is recommended to keep this small since lookup is done in N time
+    /// Creates a new `LruIndexer` with a given window size limited by the `size` parameter.
+    /// It is recommended to keep this small, since lookup is done in N time
     ///
-    /// if a new vertex is found, `emit` will be called. emit will be supplied with a
-    /// vertex and a index that was used.
+    /// If a new vertex is found, `emit` will be called. `emit` will be supplied with a
+    /// vertex and an index that was used.
     pub fn new(size: usize, emit: F) -> LruIndexer<T, F> {
         LruIndexer {
             index: 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,8 @@
 #![allow(clippy::many_single_char_names)]
 
 pub use poly::{
-    EmitLines, Line, Lines, MapToVertices, MapVertex, Polygon, Quad, Triangle, Vertices,
-    VerticesIterator,
+    EmitLines, EmitVertices, Line, Lines, LinesIterator, MapToVertices, MapToVerticesIter,
+    MapVertex, Polygon, Quad, Triangle, Vertices, VerticesIterator,
 };
 
 pub use triangulate::{EmitTriangles, Triangulate, TriangulateIterator};

--- a/src/neighbors.rs
+++ b/src/neighbors.rs
@@ -17,7 +17,7 @@ pub struct Neighbors<T> {
 }
 
 impl<T> Neighbors<T> {
-    /// Build a Neighbors search based on the supplied vertices
+    /// Builds a Neighbors search based on the supplied vertices
     /// and supplied triangle list.
     pub fn new(vertices: Vec<T>, polygons: Vec<Triangle<usize>>) -> Self {
         let mut shares_edge = HashMap::new();
@@ -39,20 +39,22 @@ impl<T> Neighbors<T> {
         }
     }
 
-    /// return the vector and triangle list used to create the Neighbors
+    /// Returns the vector and triangle list used to create the Neighbors.
     pub fn split(self) -> (Vec<T>, Vec<Triangle<usize>>) {
         (self.vertices, self.polygons)
     }
 
-    /// looks up the index of every polygon that contains
-    /// vertex t, this can be used to calculate new faces
+    /// Looks up the index of every polygon that contains
+    /// vertex `t`, this can be used to calculate new faces.
     pub fn vertex_neighbors(&self, t: &usize) -> Option<&[usize]> {
         self.shares_vertex.get(t).map(|x| &x[..])
     }
 
-    /// looks up the index of every polygon that is a neighbor of
-    /// polygon at index i. This can be used to prep data for a Geometry
-    /// shader (eg trinagle_adjacency)
+    /// Looks up the index of every [`Polygon`] that is a neighbor of the
+    /// [`Polygon`] at index `i`. This can be used to prep data for a Geometry
+    /// shader (eg triangle_adjacency).
+    ///
+    /// [`Polygon`]: enum.Polygon.html
     pub fn polygon_neighbors(&self, i: usize) -> Option<HashSet<usize>> {
         self.polygons.get(i).map(|x| {
             let mut v = HashSet::new();
@@ -68,10 +70,10 @@ impl<T> Neighbors<T> {
         })
     }
 
-    /// Calculate the normal for face. This is a `flat` shading
+    /// Calculate the normal for a face. This is a `flat` shading.
     ///
     /// You must supply a function that can be used to lookup
-    /// The position which is needed to calculate the normal
+    /// the position which is needed to calculate the normal.
     pub fn normal_for_face<F>(&self, i: usize, mut f: F) -> Normal
     where
         F: FnMut(&T) -> Normal,
@@ -88,11 +90,11 @@ impl<T> Neighbors<T> {
         a.cross(b).normalized().into()
     }
 
-    /// Calculate the normal for an vertex based on the average
-    /// of it's Neighbors this is a `smooth` shading
+    /// Calculate the normal for a vertex based on the average
+    /// of its neighbors. This is a `smooth` shading.
     ///
     /// You must supply a function that can be used to lookup
-    /// The position which is needed to calculate the normal
+    /// the position which is needed to calculate the normal.
     pub fn normal_for_vertex<F>(&self, i: usize, mut f: F) -> Normal
     where
         F: FnMut(&T) -> Normal,

--- a/src/plane.rs
+++ b/src/plane.rs
@@ -1,7 +1,7 @@
 use super::generators::{IndexedPolygon, SharedVertex};
 use super::{Quad, Vertex};
 
-/// Represents a 2D plane with origin of (0, 0), from 1 to -1
+/// Represents a 2D plane with origin of (0, 0), from 1 to -1.
 #[derive(Clone, Copy)]
 pub struct Plane {
     subdivide_x: usize,
@@ -11,7 +11,7 @@ pub struct Plane {
 }
 
 impl Plane {
-    /// create a new cube generator
+    /// Creates a new plane.
     pub fn new() -> Plane {
         Plane {
             subdivide_x: 1,
@@ -21,10 +21,17 @@ impl Plane {
         }
     }
 
-    /// create a subdivided plane. This can be used to build
+    /// Creates a subdivided plane. This can be used to build
     /// a grid of points.
-    /// `x` is the number of subdivisions in the x axis
-    /// `y` is the number of subdivisions in the y axis
+    ///
+    /// # Arguments
+    ///
+    /// - `x` is the number of subdivisions in the x axis, must be at least 1
+    /// - `y` is the number of subdivisions in the y axis, must be at least 1
+    ///
+    /// # Panics
+    ///
+    /// This function panics if either `x` or `y` is zero.
     pub fn subdivide(x: usize, y: usize) -> Plane {
         assert!(x > 0 && y > 0);
         Plane {

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -1,21 +1,21 @@
 use std::collections::VecDeque;
 use std::marker::PhantomData;
 
-/// A polygon with 4 points. Maps to `GL_QUADS`
+/// A polygon with 4 points. Maps to `GL_QUADS`.
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]
 pub struct Quad<T> {
-    /// the first point of a quad
+    /// The first point of the quad
     pub x: T,
-    /// the second point of a quad
+    /// The second point of the quad
     pub y: T,
-    /// the third point of a quad
+    /// The third point of the quad
     pub z: T,
-    /// the fourth point of a quad
+    /// The fourth point of the quad
     pub w: T,
 }
 
 impl<T> Quad<T> {
-    /// create a new `Quad` with supplied vertices
+    /// Create a new `Quad` with the supplied vertices.
     pub fn new(v0: T, v1: T, v2: T, v3: T) -> Self {
         Quad {
             x: v0,
@@ -26,19 +26,19 @@ impl<T> Quad<T> {
     }
 }
 
-/// A polygon with 3 points. Maps to `GL_TRIANGLE`
+/// A polygon with 3 points. Maps to `GL_TRIANGLE`.
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]
 pub struct Triangle<T> {
-    /// the first point of a triangle
+    /// the first point of the triangle
     pub x: T,
-    /// the second point of a triangle
+    /// the second point of the triangle
     pub y: T,
-    /// the third point of a triangle
+    /// the third point of the triangle
     pub z: T,
 }
 
 impl<T> Triangle<T> {
-    /// create a new `Triangle` with supplied vertcies
+    /// Create a new `Triangle` with the supplied vertices.
     pub fn new(v0: T, v1: T, v2: T) -> Self {
         Triangle {
             x: v0,
@@ -49,21 +49,27 @@ impl<T> Triangle<T> {
 }
 
 /// This is All-the-types container. This exists since some generators
-/// produce both `Triangles` and `Quads`.
+/// produce both [`Triangles`] and [`Quads`].
+///
+/// [`Triangles`]: struct.Triangle.html
+/// [`Quads`]: struct.Quad.html
 #[derive(Debug, Clone, PartialEq, Copy)]
 pub enum Polygon<T> {
-    /// A wraped triangle
+    /// A wrapped triangle
     PolyTri(Triangle<T>),
-    /// A wraped quad
+    /// A wrapped quad
     PolyQuad(Quad<T>),
 }
 
-/// The core mechanism of `Vertices` trait. This is a mechanism for unwraping
+/// The core mechanism of the [`Vertices`] trait. This is a mechanism for unwrapping
 /// a polygon extracting all of the vertices that it bound together.
+///
+/// [`Vertices`]: trait.Vertices.html
 pub trait EmitVertices<T> {
-    /// Consume a polygon, each
-    /// vertex is emitted to the parent function by calling the supplied
-    /// lambda function
+    /// Consume a [`Polygon`], each vertex is emitted to the parent function by
+    /// calling the supplied lambda function.
+    ///
+    /// [`Polygon`]: enum.Polygon.html
     fn emit_vertices<F>(self, f: F)
     where
         F: FnMut(T);
@@ -119,11 +125,13 @@ impl<T> EmitVertices<T> for Polygon<T> {
     }
 }
 
-/// Supplies a way to convert an iterator of polygons to an iterator
+/// Supplies a way to convert an [`Iterator`] of [`polygons`] to an [`Iterator`]
 /// of vertices. Useful for when you need to write the vertices into
 /// a graphics pipeline.
+///
+/// [`polygons`]: enum.Polygon.html
 pub trait Vertices<SRC, V> {
-    /// Convert a polygon iterator to a vertices iterator.
+    /// Convert a polygon [`Iterator`] to a vertices [`Iterator`].
     fn vertices(self) -> VerticesIterator<SRC, V>;
 }
 
@@ -136,8 +144,14 @@ impl<V, P: EmitVertices<V>, T: Iterator<Item = P>> Vertices<T, V> for T {
     }
 }
 
-/// an iterator that breaks a polygon down into its individual
-/// verticies.
+/// An [`Iterator`] that breaks a [`Polygon`] down into its individual
+/// vertices.
+///
+/// This `struct` is created by the [`vertices`] method on [`Vertices`].
+///
+/// [`Polygon`]: enum.Polygon.html
+/// [`Vertices`]: trait.Vertices.html
+/// [`vertices`]: trait.Vertices.html#method.vertices
 pub struct VerticesIterator<SRC, V> {
     source: SRC,
     buffer: VecDeque<V>,
@@ -159,12 +173,14 @@ impl<V, U: EmitVertices<V>, SRC: Iterator<Item = U>> Iterator for VerticesIterat
     }
 }
 
-/// equivalent of `map` but per-vertex
+/// Equivalent of `map` but per-vertex.
 pub trait MapVertex<T, U> {
-    /// `Output` should be a a container of the same shape of the type
+    /// `Output` should be a container of the same shape of the type.
     /// It's internal values should reflect any transformation the map did.
     type Output;
-    /// map a function to each vertex in polygon creating a new polygon
+    /// Map a function to each vertex in a [`Polygon`] creating a new [`Polygon`].
+    ///
+    /// [`Polygon`]: enum.Polygon.html
     fn map_vertex<F>(self, f: F) -> Self::Output
     where
         F: FnMut(T) -> U;
@@ -235,16 +251,18 @@ impl<T: Clone, U> MapVertex<T, U> for Polygon<T> {
 }
 
 /// This acts very similar to a vertex shader. It gives a way to manipulate
-/// and modify the vertices in a polygon. This is useful if you need to scale
-/// the mesh using a matrix multiply, or just for modifying the type of each
-/// vertex.
+/// and modify the vertices in a [`Polygon`]. This is useful if you need to
+/// scale the mesh using a matrix multiply, or just for modifying the type of
+/// each vertex.
+///
+/// [`Polygon`]: enum.Polygon.html
 pub trait MapToVertices<T, U>: Sized {
-    /// `Output` should be a a container of the same shape of the type
+    /// `Output` should be a a container of the same shape of the type.
     /// It's internal values should reflect any transformation the map did.
     type Output;
 
-    /// from a iterator of polygons, produces a iterator of polygons. Each
-    /// vertex in the process is modified with the suppled function.
+    /// Produces an [`Iterator`] of mapped polygons from an [`Iterator`] of polygons.
+    /// Each vertex in the process is modified with the supplied function.
     fn vertex<F>(self, map: F) -> MapToVerticesIter<Self, T, U, F>
     where
         F: FnMut(T) -> U;
@@ -267,6 +285,12 @@ impl<VIn, VOut, P, POut: MapVertex<VIn, VOut, Output = P>, T: Iterator<Item = PO
     }
 }
 
+/// An [`Iterator`] that maps vertices with a given function.
+///
+/// This `struct` is created by the [`vertex`] method on [`MapToVertices`].
+///
+/// [`vertex`]: trait.MapToVertices.html#method.vertex
+/// [`MapToVertices`]: trait.MapToVertices.html
 pub struct MapToVerticesIter<SRC, T, U, F: FnMut(T) -> U> {
     src: SRC,
     f: F,
@@ -294,30 +318,37 @@ impl<
     }
 }
 
-/// Represents a line
+/// Represents a line.
 #[derive(Clone, Debug, PartialEq, Eq, Copy, Hash)]
 pub struct Line<T> {
-    /// the first point
+    /// The first point
     pub x: T,
     /// The second point
     pub y: T,
 }
 
 impl<T> Line<T> {
-    /// Create a new line using point x and y
+    /// Create a new line using point x and y.
     pub fn new(x: T, y: T) -> Self {
         Line { x, y }
     }
 }
 
-/// Convert a Polygon into it's fragments
+/// Convert a [`Polygon`] into it's fragments.
+///
+/// [`Polygon`]: enum.Polygon.html
 pub trait EmitLines {
-    /// The Vertex defines the corners of a Polygon
+    /// The Vertex defines the corners of a [`Polygon`].
+    ///
+    /// [`Polygon`]: enum.Polygon.html
     type Vertex;
 
-    /// convert a polygon into lines, each line is emitted via
-    /// calling of the callback of `emit` This allow for
-    /// a variable amount of lines to be returned
+    /// Convert a polygon into lines, each [`Line`] is emitted via
+    /// calling of the callback of `emit`. This allows for
+    /// a variable amount of lines to be returned.
+    ///
+    /// [`Polygon`]: enum.Polygon.html
+    /// [`Line`]: struct.Line.html
     fn emit_lines<E>(self, emit: E)
     where
         E: FnMut(Line<Self::Vertex>);
@@ -364,12 +395,17 @@ impl<T: Clone> EmitLines for Polygon<T> {
     }
 }
 
-/// Creates an LinesIterator from another Iterator
+/// Supplies a way to convert an [`Iterator`] of [`polygons`] into an [`Iterator`] of
+/// the [`polygons`] lines
+///
+/// [`polygons`]: enum.Polygon.html
 pub trait Lines: Sized {
-    /// The type of each point in the lines
+    /// The type of each point in the lines.
     type Vertex;
 
-    /// Convert the iterator into a LinesIterator
+    /// Convert the [`Iterator`] into a [`LinesIterator`].
+    ///
+    /// [`LinesIterator`]: struct.LinesIterator.html
     fn lines(self) -> LinesIterator<Self, Self::Vertex>;
 }
 
@@ -388,7 +424,12 @@ where
     }
 }
 
-/// An iterator that turns Polygons into an Iterator of Lines
+/// An [`Iterator`] that turns polygons into an [`Iterator`] of lines.
+///
+/// This `struct` is created by the [`lines`] method on [`Lines`].
+///
+/// [`lines`]: trait.Lines.html#method.lines
+/// [`Lines`]: trait.Lines.html
 pub struct LinesIterator<I, V> {
     source: I,
     buffer: VecDeque<Line<V>>,

--- a/src/sphere.rs
+++ b/src/sphere.rs
@@ -4,7 +4,7 @@ use crate::generators::{IndexedPolygon, SharedVertex};
 use crate::Polygon::{self, PolyQuad, PolyTri};
 use crate::{Quad, Triangle, Vertex};
 
-/// Represents a sphere with radius of 1, centered at (0, 0, 0)
+/// Represents a sphere with radius of 1, centered at (0, 0, 0).
 #[derive(Clone, Copy)]
 pub struct SphereUv {
     u: usize,
@@ -14,9 +14,16 @@ pub struct SphereUv {
 }
 
 impl SphereUv {
-    /// Create a new sphere.
-    /// `u` is the number of points across the equator of the sphere.
-    /// `v` is the number of points from pole to pole.
+    /// Creates a new sphere.
+    ///
+    /// # Arguments
+    ///
+    /// - `u` is the number of points across the equator of the sphere, must be at least 2
+    /// - `v` is the number of points from pole to pole, must be at least 2
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `u` or `v` are less than 2 respectively.
     pub fn new(u: usize, v: usize) -> Self {
         assert!(u > 1 && v > 1);
         SphereUv {

--- a/src/torus.rs
+++ b/src/torus.rs
@@ -15,12 +15,18 @@ pub struct Torus {
 }
 
 impl Torus {
-    /// Create a new Torus Generator.
-    /// `radius` is the radius from the center [0, 0, 0] to the center
-    ///          of the the tubular radius
-    /// `tubular_radius` is the radius to the surface from the toridal
-    /// `tubular_segments` the number of segments that wrap around the tube, must be at least 3
-    /// `radial_segments` the number of tube segments requested to generate, must be at least 3
+    /// Creates a new torus.
+    ///
+    /// # Arguments
+    ///
+    /// - `radius` is the radius from the center [0, 0, 0] to the center of the tubular radius
+    /// - `tubular_radius` is the radius to the surface from the toridal
+    /// - `tubular_segments` is the number of segments that wrap around the tube, it must be at least 3
+    /// - `radial_segments` is the number of tube segments requested to generate, it must be at least 3
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `tubular_segments` or `radial_segments` is less than 3.
     pub fn new(
         radius: f32,
         tubular_radius: f32,

--- a/src/triangulate.rs
+++ b/src/triangulate.rs
@@ -3,14 +3,14 @@ use std::collections::VecDeque;
 use crate::Polygon::{self, PolyQuad, PolyTri};
 use crate::{Quad, Triangle};
 
-/// provides a way to convert a polygon down to triangles
+/// Provides a way to convert a polygon down to triangles.
 pub trait EmitTriangles {
-    /// The content of each point in the face
+    /// The content of each point in the triangle.
     type Vertex;
 
-    /// convert a polygon to one or more triangles, each triangle
-    /// is returned by calling `emit`
-    fn emit_triangles<F>(&self, f: F)
+    /// Convert a polygon to one or more triangles, each triangle
+    /// is returned by calling `emit`.
+    fn emit_triangles<F>(&self, emit: F)
     where
         F: FnMut(Triangle<Self::Vertex>);
 }
@@ -58,11 +58,10 @@ impl<T: Clone> EmitTriangles for Polygon<T> {
     }
 }
 
-/// `Triangluate` is a easy to to convert any Polygon stream to
-/// a stream of triangles. This is useful since Quads and other geometry
-/// are not supported by modern graphics pipelines like OpenGL.
+/// A trait to easily convert any polygon [`Iterator`] into a triangle [`Iterator`].
+/// This is useful since Quads and other geometry are not supported by modern graphics pipelines like OpenGL.
 pub trait Triangulate<T, V> {
-    /// convert a stream of Polygons to a stream of triangles
+    /// Convert an [`Iterator`] of polygons into an [`Iterator`] of triangles.
     fn triangulate(self) -> TriangulateIterator<T, V>;
 }
 
@@ -72,7 +71,12 @@ impl<V, P: EmitTriangles<Vertex = V>, T: Iterator<Item = P>> Triangulate<T, V> f
     }
 }
 
-/// Used to iterator of polygons into a iterator of triangles
+/// An [`Iterator`] that turns an [`Iterator`] of polygons into an [`Iterator`] of triangles.
+///
+/// This `struct` is created by the [`triangulate`] method on [`Triangulate`].
+///
+/// [`triangulate`]: trait.Triangulate.html#method.triangulate
+/// [`Triangulate`]: trait.Triangulate.html
 pub struct TriangulateIterator<SRC, V> {
     source: SRC,
     buffer: VecDeque<Triangle<V>>,


### PR DESCRIPTION
While doing the changes I did yesterday I noticed that the docs were a bit chaotic and since the changes might make for a (minor?) release soon, I figured it would be a good time to also try improving the docs slightly.