### PR TITLE
feature: Add an into() bevy mesh, example viewer.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = [
     "Coraline Sherratt <cora.sherratt@gmail.com>",
     "Dzmitry Malyshau <kvarkus@gmail.com>",
 ]
+resolver = "2"
 
 license = "Apache-2.0"
 description = "A package for generating 3D meshes"
@@ -12,11 +13,17 @@ homepage = "https://github.com/gfx-rs/genmesh"
 repository = "https://github.com/gfx-rs/genmesh"
 edition = "2018"
 
+[features]
+default = []
+into_bevy_mesh = ["dep:bevy_render", "dep:glam"]
+
 [lib]
 name = "genmesh"
 path = "src/lib.rs"
 
 [dependencies]
+bevy_render = { version = "0.10.1", default-features = false, optional = true }
+glam = { version = "0.23.0", features = ["mint"], optional = true }
 mint = "0.5"
 
 [dev-dependencies]

--- a/examples/viewer/Cargo.toml
+++ b/examples/viewer/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "viewer"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bevy = "0.10.1"
+bevy_panorbit_camera = "0.2.0"
+genmesh = { version = "0.6.2", path = "../..", features= ["into_bevy_mesh"] }
+glam = { version = "0.23.0", features = ["mint"] }

--- a/examples/viewer/src/main.rs
+++ b/examples/viewer/src/main.rs
@@ -1,0 +1,171 @@
+use bevy::prelude::*;
+use bevy::render::{mesh::Indices, render_resource::PrimitiveTopology};
+use bevy_panorbit_camera::{PanOrbitCamera, PanOrbitCameraPlugin};
+
+use genmesh::{
+    generators::{
+        self, Circle, Cone, Cube, Cylinder, IcoSphere, IndexedPolygon, Plane, SharedVertex,
+        SphereUv, Torus,
+    },
+    Triangulate, Vertices,
+};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_startup_system(setup)
+        .add_system(bevy::window::close_on_esc)
+        .add_plugin(PanOrbitCameraPlugin)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>) {
+    // Add a camera so we can see the generators.
+    commands
+        .spawn(Camera3dBundle {
+            transform: Transform::from_xyz(-2.0, 3.0, 25.0).looking_at(Vec3::ZERO, Vec3::Y),
+            ..default()
+        })
+        .insert(PanOrbitCamera {
+            radius: 25.,
+            ..default()
+        });
+
+    // commands.spawn(PointLightBundle {
+    //     transform: Transform::from_xyz(-3., 3., 10.),
+    //     point_light: PointLight {
+    //         intensity: 10000.,
+    //         // shadows_enabled: true,
+    //         ..default()
+    //     },
+    //     ..default()
+    // });
+
+    commands.spawn(DirectionalLightBundle {
+        transform: Transform::from_xyz(-10., 10., 10.).looking_at(Vec3::ZERO, Vec3::Y),
+        directional_light: DirectionalLight {
+            illuminance: 10000.,
+            shadows_enabled: true,
+            ..default()
+        },
+        ..default()
+    });
+
+    // Add a ground plane.
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(shape::Plane::from_size(50.0).into()),
+        material: materials.add(Color::rgb(0.5, 0.5, 0.5).into()),
+        transform: Transform::from_xyz(0.0, -1.0, 0.0),
+        ..default()
+    });
+
+    // commands.spawn(PbrBundle {
+    //     mesh: meshes.add(shape::Cube { size: 1.0 }.into()),
+    //     material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+    //     transform: Transform::from_xyz(0., 0., 0.),
+    //     ..default()
+    // });
+        None
+        None
+        Some(shape::Cube::default().into()),
+        // Some(shape::Box::default().into()),
+        Some(shape::Capsule::default().into()),
+        Some(shape::Cylinder::default().into()),
+        Some(shape::Icosphere::default().try_into().unwrap()),
+        None
+        Some(shape::UVSphere::default().into()),
+        Some(shape::Torus::default().into()),
+
+    let generators: Vec<Mesh> = vec![
+        Circle::new(10).into(),
+        Cone::new(10).into(),
+        Cube::new().into(),
+        Cylinder::new(10).into(),
+        IcoSphere::new().into(),
+        Plane::new().into(),
+        SphereUv::new(10, 10).into(),
+        Torus::new(1., 1., 10, 10).into(),
+    ];
+    let count = generators.len();
+
+    // Make a bevy mesh by hand.
+    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
+    let generator = generators::Cube::new();
+    let vertices: Vec<_> = generator
+        .shared_vertex_iter()
+        .map(|v| Vec3::new(v.pos.x / 2., v.pos.y / 2., v.pos.z / 2.))
+        .collect();
+    let normals: Vec<_> = generator
+        .shared_vertex_iter()
+        .map(|v| Vec3::new(v.normal.x, v.normal.y, v.normal.z))
+        .collect();
+    let indices: Vec<u32> = generator
+        .indexed_polygon_iter()
+        .triangulate()
+        .vertices()
+        .map(|u| u as u32)
+        .collect();
+    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+    mesh.set_indices(Some(Indices::U32(indices)));
+
+    for (i, mesh) in generators.into_iter().enumerate() {
+        commands.spawn(PbrBundle {
+            mesh: meshes.add(mesh),
+            material: materials.add(Color::rgb(1., 1., 1.).into()),
+            // transform: Transform::from_xyz(3. * (i - count / 2) as f32, 0., 0.),
+            transform: Transform::from_xyz(3. * (i as f32 - count as f32 / 2.), 0., 0.),
+            ..default()
+        });
+    }
+
+    // commands.spawn(PbrBundle {
+    //     mesh: meshes.add(mesh),
+    //     material: materials.add(Color::rgb(0.8, 0.3, 0.3).into()),
+    //     transform: Transform::from_xyz(1.5, 0., 0.),
+    //     ..default()
+    // });
+
+    // commands.spawn(PbrBundle {
+    //     mesh: meshes.add(Cube::new().into()),
+    //     material: materials.add(Color::rgb(0.3, 0.8, 0.3).into()),
+    //     transform: Transform::from_xyz(3.5, 0., 0.),
+    //     ..default()
+    // });
+
+    // commands.spawn(PbrBundle {
+    //     mesh: meshes.add(generators::SphereUv::new(10, 10).into()),
+    //     material: materials.add(Color::rgb(0.3, 0.3, 0.8).into()),
+    //     transform: Transform::from_xyz(5.5, 0., 0.),
+    //     ..default()
+    // });
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn vertices_as_indices() {
+        let generator = generators::Cube::new();
+        let first = generator
+            .indexed_polygon_iter()
+            .triangulate()
+            .vertices()
+            .map(|i| i as u32)
+            .next();
+        assert_eq!(Some(0u32), first);
+    }
+
+    #[test]
+    fn vertices_as_vectors() {
+        let generator = generators::Cube::new();
+        let first = generator
+            .triangulate()
+            .vertices()
+            .map(|v| v.pos.into())
+            .next();
+        assert_eq!(Some(Vec3::new(1., 1., -1.)), first);
+    }
+}

--- a/src/bevy_compat.rs
+++ b/src/bevy_compat.rs
@@ -1,0 +1,88 @@
+use glam::Vec3;
+use bevy_render::{mesh::{Mesh, Indices}, render_resource::PrimitiveTopology};
+use crate::{
+    generators::{IndexedPolygon, SharedVertex,
+    Circle,
+    Cone,
+    Cube,
+    Cylinder,
+    IcoSphere,
+    Plane,
+    SphereUv,
+    Torus,
+    },
+    EmitTriangles, Triangulate, Vertex, Vertices,
+};
+
+impl From<Cube> for Mesh {
+    fn from(generator: Cube) -> Self {
+        build_mesh(generator)
+    }
+}
+
+impl From<Circle> for Mesh {
+    fn from(generator: Circle) -> Self {
+        build_mesh(generator)
+    }
+}
+impl From<Cone> for Mesh {
+    fn from(generator: Cone) -> Self {
+        build_mesh(generator)
+    }
+}
+
+impl From<Cylinder> for Mesh {
+    fn from(generator: Cylinder) -> Self {
+        build_mesh(generator)
+    }
+}
+
+impl From<IcoSphere> for Mesh {
+    fn from(generator: IcoSphere) -> Self {
+        build_mesh(generator)
+    }
+}
+
+impl From<Plane> for Mesh {
+    fn from(generator: Plane) -> Self {
+        build_mesh(generator)
+    }
+}
+
+impl From<SphereUv> for Mesh {
+    fn from(generator: SphereUv) -> Self {
+        build_mesh(generator)
+    }
+}
+
+impl From<Torus> for Mesh {
+    fn from(generator: Torus) -> Self {
+        build_mesh(generator)
+    }
+}
+
+/// Build a bevy mesh from a generator.
+pub fn build_mesh<T, P>(generator: T) -> Mesh
+where
+    T: SharedVertex<Vertex> + IndexedPolygon<P>,
+    P: EmitTriangles<Vertex = usize>,
+{
+    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
+    let (vertices, normals): (Vec<Vec3>, Vec<Vec3>) = generator
+        .shared_vertex_iter()
+        .map(|v| {
+            let w: (Vec3, Vec3) = (v.pos.into(), v.normal.into());
+            w
+        })
+        .unzip();
+    let indices: Vec<u32> = generator
+        .indexed_polygon_iter()
+        .triangulate()
+        .vertices()
+        .map(|u| u as u32)
+        .collect();
+    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, vertices);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+    mesh.set_indices(Some(Indices::U32(indices)));
+    mesh
+}

--- a/src/cone.rs
+++ b/src/cone.rs
@@ -51,7 +51,7 @@ impl Cone {
                     normal: [
                         pos.cos() * FRAC_1_SQRT_2,
                         pos.sin() * FRAC_1_SQRT_2,
-                        -FRAC_1_SQRT_2,
+                        FRAC_1_SQRT_2,
                     ]
                     .into(),
                 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -106,3 +106,4 @@ impl<'a, T: IndexedPolygon<V>, V> ExactSizeIterator for IndexedPolygonIterator<'
         self.idx.len()
     }
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,3 +71,7 @@ pub struct Vertex {
     /// Vertex normal
     pub normal: Normal,
 }
+
+/// Provides generator into bevy mesh functionality.
+#[cfg(feature = "into_bevy_mesh")]
+pub mod bevy_compat;


### PR DESCRIPTION
Add a cargo feature "into_bevy_mesh" that will provide a `From` implementation so generators like `Cube` can be turned into a bevy `Mesh`. This doesn't add any dependencies on the default features. It does add dependencies on `bevy_render` and `glam` when the feature is enabled.

Add an example called "viewer" that uses this feature to view the generators. It's a small bevy app with some camera control. I did discover a bug in a cone normal so plus one for visualization.